### PR TITLE
Fix for bug that caused wrong namespace name be output in SWIG code

### DIFF
--- a/doxy2swig.py
+++ b/doxy2swig.py
@@ -397,10 +397,16 @@ class Doxy2SWIG:
         as keys, and a list of corresponding memberdef nodes as values."""
         sig_dict = {}
         sig_prefix = ''
-        if kind in ('file', 'namespace'):
+		
+        if kind in ('file'):
+			# TODO: This is still not correct as files may have multiple innernamespace tags, but I don't know
+			# if any information is actually extracted from <compounddef kind="file"... tags?
             ns_node = node.getElementsByTagName('innernamespace')
-            if not ns_node and kind == 'namespace':
-                ns_node = node.getElementsByTagName('compoundname')
+            if ns_node:
+                sig_prefix = self.extract_text(ns_node[0]) + '::'
+        elif kind in ('namespace'):
+			# Namespace name is stored in compoundname tag.
+            ns_node = node.getElementsByTagName('compoundname')
             if ns_node:
                 sig_prefix = self.extract_text(ns_node[0]) + '::'
         elif kind in ('class', 'struct'):

--- a/doxy2swig.py
+++ b/doxy2swig.py
@@ -397,15 +397,15 @@ class Doxy2SWIG:
         as keys, and a list of corresponding memberdef nodes as values."""
         sig_dict = {}
         sig_prefix = ''
-		
+        
         if kind in ('file'):
-			# TODO: This is still not correct as files may have multiple innernamespace tags, but I don't know
-			# if any information is actually extracted from <compounddef kind="file"... tags?
+            # TODO: This is still not correct as files may have multiple innernamespace tags, but I don't know
+            # if any information is actually extracted from <compounddef kind="file"... tags?
             ns_node = node.getElementsByTagName('innernamespace')
             if ns_node:
                 sig_prefix = self.extract_text(ns_node[0]) + '::'
         elif kind in ('namespace'):
-			# Namespace name is stored in compoundname tag.
+            # Namespace name is stored in compoundname tag.
             ns_node = node.getElementsByTagName('compoundname')
             if ns_node:
                 sig_prefix = self.extract_text(ns_node[0]) + '::'


### PR DESCRIPTION
Fixes a bug that causes namespace name be read from the first <innernamespace> tag. That is not correct when there are multiple inner namespaces present. The fix is not thoroughly tested, it is only used in single but relatively complicated project.